### PR TITLE
🔧 Hotfix: Remove unused Badge import - Fix ESLint build error

### DIFF
--- a/frontend/src/app/admin/layout.tsx
+++ b/frontend/src/app/admin/layout.tsx
@@ -5,7 +5,6 @@ import { useRouter, usePathname } from 'next/navigation';
 import Link from 'next/link';
 import '@/styles/admin-dashboard.css';
 import { Button } from '@/components/ui/button';
-import { Badge } from '@/components/ui/badge';
 import { Separator } from '@/components/ui/separator';
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 import {


### PR DESCRIPTION
## 🚨 **Hotfix: ESLint Build Error**

This is a critical hotfix to resolve the production build failure caused by an unused import.

### 🐛 **Problem**

The production build was failing with this ESLint error:
```
./src/app/admin/layout.tsx
8:10  Error: 'Badge' is defined but never used.  @typescript-eslint/no-unused-vars
```

### ✅ **Solution**

- **Removed unused `Badge` import** from `frontend/src/app/admin/layout.tsx`
- **Fixed TypeScript/ESLint no-unused-vars error**
- **Production build now passes successfully**

### 📁 **Files Changed**

- `frontend/src/app/admin/layout.tsx` - Removed unused Badge import

### 🧪 **Verification**

- ✅ `npm run lint` passes with no errors
- ✅ `npm run build` completes successfully
- ✅ No functionality affected (Badge was not being used)

### 🚀 **Impact**

- **Zero functional changes** - only removes unused import
- **Fixes production build pipeline**
- **Maintains all existing sidebar functionality**

---

**This hotfix should be merged immediately to restore production builds.** 🔥

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author